### PR TITLE
Add cross compile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ You can specifc the name of the config file as the first argument:
 
 If no file is specified then the tool will look for a file named `config.toml` in the current working directory.
 
+## Building
+You can build from source:
+
+~~~ sh
+> ./build [platform]
+~~~
+
 ## Operation
 The `photorg` tool will move and all photos from the `SourcePath` into the `DestRoot`, creating a tree like:
 


### PR DESCRIPTION
Added section to README to start conversation.

I think it would be relatively easy to add cross compile support for the following platforms:
- [x] Add section to readme
- [ ] Darwin (Mac OSX) x64
- [ ] Win32
- [ ] Win64
- [ ] linux32
- [ ] linux64
